### PR TITLE
Fix Hermes build to use correct compilers on macOS

### DIFF
--- a/cmake/HermesExternal.cmake
+++ b/cmake/HermesExternal.cmake
@@ -107,6 +107,8 @@ else()
         LOG_BUILD ON
         LOG_OUTPUT_ON_FAILURE ON
         UPDATE_DISCONNECTED ON
+        ENV CC ${CMAKE_C_COMPILER}
+        ENV CXX ${CMAKE_CXX_COMPILER}
     )
 
     # Set tool paths (these will be valid after Hermes is built)


### PR DESCRIPTION
Ensure CC and CXX environment variables are set for the Hermes
external project to match the main project's compilers. This fixes
linking issues where the wrong compiler toolchain was being used
for the final link step.

test env:
```bash
sw_vers
ProductName:		macOS
ProductVersion:		26.1
BuildVersion:		25B78
```