### PR TITLE
use requestAnimationFrame to drive animations

### DIFF
--- a/lib/jslib-unit/jslib.js
+++ b/lib/jslib-unit/jslib.js
@@ -97,6 +97,55 @@
         }
     }
 
+    // requestAnimationFrame polyfill that adapts to the host's tick rate.
+    // We batch callbacks and flush them on the next macro task, so the
+    // frequency naturally follows the platform refresh cadence (e.g., 60/90/120Hz)
+    // if the host drives the event loop once per frame.
+    var rafQueue = {};
+    var rafNextId = 1;
+
+    function flushRaf() {
+        // Take a snapshot of callbacks and clear the queue so rAFs scheduled
+        // inside a callback run on the next tick (matching browser semantics).
+        var cbs = [];
+        for (var id in rafQueue) {
+            if (Object.prototype.hasOwnProperty.call(rafQueue, id)) {
+                cbs.push(rafQueue[id]);
+                delete rafQueue[id];
+            }
+        }
+        var ts = curTime;
+        for (var i = 0; i < cbs.length; i++) {
+        try {
+            cbs[i](ts);
+        } catch (e) {
+            try {
+                if (
+                    globalThis &&
+                    globalThis.console &&
+                    typeof globalThis.console.error === 'function'
+                ) {
+                    globalThis.console.error(e);
+                } else if (typeof print === 'function') {
+                    print('ERROR:', String(e && e.message ? e.message : e));
+                }
+            } catch (_) {}
+        }
+        }
+    }
+
+    function requestAnimationFrame(callback) {
+        var id = rafNextId++;
+        rafQueue[id] = callback;
+        return id;
+    }
+
+    function cancelAnimationFrame(id) {
+        if (rafQueue[id]) {
+        delete rafQueue[id];
+        }
+    }
+
     // Expose to global scope
     globalThis.setTimeout = setTimeout;
     globalThis.clearTimeout = clearTimeout;
@@ -104,6 +153,8 @@
     globalThis.clearImmediate = clearImmediate;
     globalThis.setInterval = setInterval;
     globalThis.clearInterval = clearInterval;
+    globalThis.requestAnimationFrame = requestAnimationFrame;
+    globalThis.cancelAnimationFrame = cancelAnimationFrame;
 
     // Polyfills needed by React
     // NODE_ENV will be set from C++ based on build configuration
@@ -168,5 +219,5 @@
     };
 
     // Return helper functions for C++ to use
-    return {peek: peekMacroTask, run: runMacroTask};
+    return {peek: peekMacroTask, run: runMacroTask, flushRaf};
 })();


### PR DESCRIPTION
Adds `requestAnimationFrame` global function that schedules next animation frame and flushes all scheduled callbacks of the current frame after all macro tasks were executed but before `on_frame` is called. This way animations run at device's refresh rate (120hz on my laptop for example) instead of hardcoded 16ms interval.